### PR TITLE
Fixed creative getting of achievements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version_forge=12.16.1.1909-1.9.4
+version_forge=12.17.0.1909-1.9.4
 version_minecraft=1.9.4
 version_major=0
 version_minor=2

--- a/src/main/java/betterachievements/handler/message/AchievementUnlockMessage.java
+++ b/src/main/java/betterachievements/handler/message/AchievementUnlockMessage.java
@@ -51,11 +51,8 @@ public class AchievementUnlockMessage implements IMessage, IMessageHandler<Achie
 
     private void unlockAchievement(Achievement achievement, EntityPlayer player)
     {
-        Achievement parent = achievement.parentAchievement;
-        while (achievement.parentAchievement != null)
-        {
-            player.addStat(achievement);
-            parent = parent.parentAchievement;
-        }
+        if (achievement.parentAchievement != null)
+            unlockAchievement(achievement.parentAchievement, player);
+        player.addStat(achievement);
     }
 }


### PR DESCRIPTION
Changed back to previous implementation of giving creative players achievements as the new way crashes the player.

To setup the project I had to chance to a proper version of Forge and update the ForgeGradle version
The forge version specified does not exist, you can see [here](http://files.minecraftforge.net/maven/net/minecraftforge/forge/index_1.9.4.html) and clicking on **Show all downloads**
