### PR TITLE
Iterates when giving multiple achievements and changed permission needed

### DIFF
--- a/src/main/java/betterachievements/registry/AchievementRegistry.java
+++ b/src/main/java/betterachievements/registry/AchievementRegistry.java
@@ -108,6 +108,7 @@ public final class AchievementRegistry
 
     public Achievement getAchievement(String statId)
     {
+        if (this.firstLoad) init();
         return this.statIdMap.get(statId);
     }
 


### PR DESCRIPTION
Changed to an iterative method of giving multiple achievements as discuses in #37 
Fixed giving achievements on a server because of never being loaded and makes sure it's run on the minecraft thread and not netty.
Makes sure that the user has permission to execute commands before giving achievements, matching vanilla commands for giving achievements.
